### PR TITLE
tests(webapp): add async FastAPI integration tests and docs; fix conc…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 pythonpath = .
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic>=2.8
 pydantic-settings>=2.2
 pytest>=8.0
 pytest-asyncio>=0.23
+httpx>=0.27

--- a/src/webapp/service.py
+++ b/src/webapp/service.py
@@ -50,6 +50,19 @@ class PersistentTokenManager(HHTokenManager):
 
     async def get_valid_access_token(self) -> str:  # type: ignore[override]
         async with self._lock:
+            # Перед попыткой refresh синхронизируемся с актуальным состоянием из стораджа
+            latest = self._storage.get(self._hr_id)
+            if latest:
+                # Если в хранилище токены/срок отличаются — обновим локальное состояние
+                if (
+                    self.access_token != latest.get("access_token")
+                    or self.refresh_token != latest.get("refresh_token")
+                    or float(self.expires_at) < float(latest.get("expires_at", 0))
+                ):
+                    self.access_token = latest["access_token"]
+                    self.refresh_token = latest["refresh_token"]
+                    self.expires_at = float(latest["expires_at"])
+
             token_before = self.access_token
             res = await super().get_valid_access_token()
             # Если токены могли обновиться — сохраняем
@@ -89,4 +102,3 @@ async def exchange_code_for_tokens(
             "refresh_token": data.get("refresh_token", ""),
             "expires_at": expires_at,
         }
-

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,41 @@
+# Тесты проекта — краткое руководство
+
+Цель: дать быстрый обзор того, что именно мы проверяем, как запускать тесты и как их расширять.
+
+Состав
+- hh_adapter:
+  - tests/hh_adapter/test_token_manager.py — проверяет жизненный цикл OAuth2‑токенов в HHTokenManager: возврат валидного токена, авто‑refresh истёкшего токена.
+- callback_server:
+  - tests/callback_server/test_code_handler.py — файл‑ориентированная логика: запись/чтение/очистка кода авторизации для демо‑callback сервера.
+- webapp (интеграционные async‑тесты FastAPI):
+  - tests/webapp/test_webapp_auth_and_storage.py — флоу `/auth/hh/start` и `/auth/hh/callback`, создание и одноразовое потребление `state`, сохранение токенов в SQLite, обработка невалидного `state`.
+  - tests/webapp/test_webapp_vacancies_concurrency.py — конкурентные запросы к `/vacancies` при истёкшем токене: проверяем, что срабатывает авто‑refresh и он выполняется ровно один раз на HR (per‑HR лок + синхронизация со сторожем).
+
+Как запускать
+- Установка зависимостей: `pip install -r requirements.txt`
+- Запуск всех тестов: `pytest -q`
+- Только webapp: `pytest -q tests/webapp`
+- Запуск отдельного теста/кейса: `pytest -q tests/webapp/test_webapp_auth_and_storage.py::test_callback_exchanges_tokens_and_redirects`
+
+Изоляция окружения
+- База данных: каждый тест webapp использует временную SQLite‑БД через переменную окружения `WEBAPP_DB_PATH` (см. `tests/webapp/conftest.py`). Это гарантирует отсутствие побочных эффектов между прогонами.
+- Сеть: внешние HTTP‑вызовы замоканы (patch на `exchange_code_for_tokens`, `_refresh_token`, `HHApiClient.request`), поэтому доступ в интернет не требуется.
+- HH‑настройки: фикстура задаёт `HH_CLIENT_ID/HH_CLIENT_SECRET/HH_REDIRECT_URI` для стабильности.
+
+Что валидируется (контракты)
+- OAuth state: одноразовость и ограниченный TTL (в коде по умолчанию 600 сек; в тестах проверяем одноразовость и корректность ошибок, TTL‑тест можно добавить отдельно).
+- Хранилище токенов: корректное сохранение/чтение `access_token`, `refresh_token`, `expires_at`.
+- Конкурентность: один refresh при множественных параллельных запросах за счёт per‑HR `asyncio.Lock` и ресинхронизации состояния токенов из персистентного стораджа.
+- Коды ответов: 2xx для успешных путей, 4xx для ошибок валидации (например, невалидный state).
+
+Подсказки и расширение
+- Предупреждение pytest‑asyncio о loop scope можно снять, задав в `pytest.ini`: `asyncio_default_fixture_loop_scope = function`.
+- Дополнительно стоит покрыть:
+  - TTL истечение `state` (перемотка времени/monkeypatch time.time/freezegun).
+  - `/healthz` и `/readyz`.
+  - Ошибки обновления токена (например, 401 от провайдера): маппинг в 401/502 на нашем REST.
+  - Rate limit/backoff у HH API (через моки и ретраи).
+
+Требования
+- pytest, pytest‑asyncio, httpx (ASGITransport), aiohttp — уже включены в `requirements.txt`.
+

--- a/tests/webapp/README.md
+++ b/tests/webapp/README.md
@@ -1,0 +1,27 @@
+# WebApp тесты (FastAPI) — кратко
+
+Назначение: проверить, что новый модуль `src/webapp` обеспечивает корректный OAuth‑флоу, персистентное хранение токенов и устойчивость при конкурентном доступе.
+
+Файлы
+- conftest.py — фикстуры:
+  - Создаёт temp SQLite и прокидывает `WEBAPP_DB_PATH`.
+  - Задает тестовые `HH_CLIENT_ID/HH_CLIENT_SECRET/HH_REDIRECT_URI`.
+  - Поднимает `httpx.AsyncClient` через `ASGITransport` поверх FastAPI‐приложения (без реального сервера).
+- test_webapp_auth_and_storage.py — сценарии авторизации и хранения:
+  - `/auth/hh/start`: редирект 302 на HH с корректными query, создание одноразового `state`.
+  - `/auth/hh/callback`: мок обмена кода на токены, сохранение `access/refresh/expires_at`, редирект на `redirect_to`.
+  - Неверный `state`: 400 `Invalid or expired state`.
+- test_webapp_vacancies_concurrency.py — конкурентность и авто‑refresh:
+  - Предзаполняем истёкший `access_token` и валидный `refresh_token` в SQLite.
+  - Патчим `_refresh_token` и `HHApiClient.request` (без внешней сети).
+  - 20 параллельных `/vacancies` → все успешны, refresh происходит ровно один раз (per‑HR лок + синхронизация со стором).
+
+Запуск
+- `pip install -r requirements.txt`
+- `pytest -q tests/webapp`
+
+Заметки
+- Тесты не используют реальную БД из корня репозитория, а создают временную.
+- TTL `state` по умолчанию 600 сек; при необходимости можно добавить тест истечения TTL (через freezegun/monkeypatch времени).
+- Предупреждение pytest‑asyncio о loop scope можно устранить настройкой в `pytest.ini`.
+

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -1,0 +1,46 @@
+# --- agent_meta ---
+# role: test-fixtures
+# owner: @backend
+# contract: Фикстуры для webapp: изолированная БД, окружение HH_*, httpx AsyncClient
+# last_reviewed: 2025-08-10
+# --- /agent_meta ---
+
+import os
+import importlib
+import types
+from typing import Generator, Tuple
+
+import pytest
+import httpx
+
+
+@pytest.fixture()
+def app_ctx(tmp_path, monkeypatch) -> Generator[Tuple[types.ModuleType, str], None, None]:
+    """
+    Инициализирует окружение для webapp с отдельной SQLite БД и настраивает HH_* env vars.
+    Возвращает кортеж (модуль webapp.app, путь к БД).
+    """
+    db_path = tmp_path / "app.sqlite3"
+
+    # Окружение для настроек HH
+    monkeypatch.setenv("HH_CLIENT_ID", "test_client")
+    monkeypatch.setenv("HH_CLIENT_SECRET", "test_secret")
+    monkeypatch.setenv("HH_REDIRECT_URI", "http://localhost/auth/hh/callback")
+    # Указываем путь БД для webapp storage/state
+    monkeypatch.setenv("WEBAPP_DB_PATH", str(db_path))
+
+    # Импортируем/перезагружаем модуль, чтобы подхватил env
+    if "src.webapp.app" in importlib.sys.modules:
+        importlib.reload(importlib.import_module("src.webapp.app"))
+    app_module = importlib.import_module("src.webapp.app")
+
+    yield app_module, str(db_path)
+
+
+@pytest.fixture()
+async def async_client(app_ctx):
+    app_module, _ = app_ctx
+    transport = httpx.ASGITransport(app=app_module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+

--- a/tests/webapp/test_webapp_auth_and_storage.py
+++ b/tests/webapp/test_webapp_auth_and_storage.py
@@ -1,0 +1,94 @@
+# --- agent_meta ---
+# role: integration-test
+# owner: @backend
+# contract: Проверяет start/callback флоу, сохранение токенов и валидацию state
+# last_reviewed: 2025-08-10
+# dependencies: [pytest, httpx]
+# --- /agent_meta ---
+
+import time
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+from src.webapp.storage import OAuthStateStore, TokenStorage
+
+
+@pytest.mark.asyncio
+async def test_auth_start_saves_state_and_redirects(async_client, app_ctx):
+    app_module, db_path = app_ctx
+
+    resp = await async_client.get(
+        "/auth/hh/start",
+        params={"hr_id": "hr_1", "redirect_to": "http://example.local/ok"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+
+    parsed = urlparse(location)
+    qs = parse_qs(parsed.query)
+    assert "client_id" in qs and qs["client_id"][0] == "test_client"
+    assert "redirect_uri" in qs
+    assert "state" in qs and qs["state"][0]
+
+    state = qs["state"][0]
+    # Проверяем, что состояние сохранено в БД и содержит правильные данные
+    store = OAuthStateStore(db_path)
+    consumed = store.consume(state)
+    assert consumed is not None
+    assert consumed["hr_id"] == "hr_1"
+    assert consumed["redirect_to"] == "http://example.local/ok"
+
+
+@pytest.mark.asyncio
+async def test_callback_exchanges_tokens_and_redirects(monkeypatch, async_client, app_ctx):
+    app_module, db_path = app_ctx
+
+    # Сначала создадим валидный state через /start
+    start = await async_client.get(
+        "/auth/hh/start",
+        params={"hr_id": "hr_2", "redirect_to": "http://example.local/back"},
+        follow_redirects=False,
+    )
+    state = parse_qs(urlparse(start.headers["location"]).query)["state"][0]
+
+    # Мокаем обмен кода на токены, чтобы не ходить во внешний сервис
+    async def fake_exchange(session, settings, code):
+        return {
+            "access_token": "access_ABC",
+            "refresh_token": "refresh_DEF",
+            "expires_at": time.time() + 3600,
+        }
+
+    # Важно патчить точку использования в модуле приложения, а не определение
+    monkeypatch.setattr("src.webapp.app.exchange_code_for_tokens", fake_exchange)
+
+    # Вызываем callback
+    cb = await async_client.get(
+        "/auth/hh/callback",
+        params={"code": "test_code", "state": state},
+        follow_redirects=False,
+    )
+
+    assert cb.status_code == 302
+    assert cb.headers["location"] == "http://example.local/back"
+
+    # Проверяем, что токены сохранились
+    storage = TokenStorage(db_path)
+    row = storage.get("hr_2")
+    assert row is not None
+    assert row["access_token"] == "access_ABC"
+    assert row["refresh_token"] == "refresh_DEF"
+    assert row["expires_at"] > time.time()
+
+
+@pytest.mark.asyncio
+async def test_callback_with_invalid_state_returns_400(async_client):
+    resp = await async_client.get(
+        "/auth/hh/callback",
+        params={"code": "any", "state": "nonexistent"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"].startswith("Invalid or expired state")

--- a/tests/webapp/test_webapp_vacancies_concurrency.py
+++ b/tests/webapp/test_webapp_vacancies_concurrency.py
@@ -1,0 +1,72 @@
+# --- agent_meta ---
+# role: integration-test
+# owner: @backend
+# contract: Проверяет авто-refresh токена и что при конкуренции refresh вызывается ровно один раз
+# last_reviewed: 2025-08-10
+# dependencies: [pytest, httpx]
+# --- /agent_meta ---
+
+import asyncio
+import time
+from typing import List
+
+import pytest
+
+from src.webapp.storage import TokenStorage
+
+
+@pytest.mark.asyncio
+async def test_vacancies_concurrent_requests_trigger_single_refresh(monkeypatch, async_client, app_ctx):
+    app_module, db_path = app_ctx
+
+    # Предзаполняем БД истекшим access_token и валидным refresh_token
+    storage = TokenStorage(db_path)
+    storage.save(
+        "hr_race",
+        {
+            "access_token": "expired",
+            "refresh_token": "refresh_ok",
+            "expires_at": time.time() - 10,  # уже истек
+        },
+    )
+
+    # Счетчик вызовов refresh
+    refresh_calls: List[int] = []
+
+    async def fake_refresh(self):  # type: ignore[no-redef]
+        # Имитация запроса к OAuth (без сети) и обновления токена
+        await asyncio.sleep(0.01)
+        refresh_calls.append(1)
+        self._update_tokens(
+            {
+                "access_token": "fresh_token",
+                "refresh_token": "refresh_ok",  # не меняем
+                "expires_in": 3600,
+            }
+        )
+
+    # Патчим низкоуровневое обновление токена у базового менеджера
+    monkeypatch.setattr("src.hh_adapter.tokens.HHTokenManager._refresh_token", fake_refresh)
+
+    # Патчим клиент HH API, чтобы он не делал внешний HTTP, но при этом приводил к получению токена
+    async def fake_request(self, endpoint: str, method: str = "GET", data=None, params=None):  # type: ignore[no-redef]
+        _ = await self._token_manager.get_valid_access_token()
+        return {"vacancies": []}
+
+    monkeypatch.setattr("src.hh_adapter.client.HHApiClient.request", fake_request)
+
+    # Запускаем пачку параллельных запросов, которые приведут к гонке за refresh
+    N = 20
+    calls = [
+        async_client.get("/vacancies", params={"hr_id": "hr_race", "text": "python"})
+        for _ in range(N)
+    ]
+    results = await asyncio.gather(*calls)
+
+    # Все запросы успешны
+    assert all(r.status_code == 200 for r in results)
+    assert all(r.json() == {"vacancies": []} for r in results)
+
+    # Обновление токена произошло ровно один раз
+    assert len(refresh_calls) == 1
+


### PR DESCRIPTION
- Контекст: добавили новый модуль webapp (FastAPI) для прод‑флоу OAuth HH.ru. Эт
от PR добавляет интеграционные тесты и исправляет гонку при авто‑refresh токенов
.
- Что сделано:
  - tests/webapp/: conftest с изолированной SQLite (WEBAPP_DB_PATH) и httpx ASGI
‑клиентом.
  - Тесты start/callback: корректный редирект, одноразовый state, сохранение ток
енов, обработка невалидного state.
  - Тест конкурентности: 20 параллельных запросов к /vacancies → один refresh на
 HR (per‑HR lock + синхронизация со стораджем).
  - src/webapp/service.py: PersistentTokenManager перед refresh синхронизируется
 с TokenStorage под тем же локом, чтобы исключить повторные обновления.
  - Тесты: monkeypatch функции exchange_code_for_tokens по месту использования (
src.webapp.app.exchange_code_for_tokens), чтобы моки срабатывали корректно.
  - Документация: tests/README.md и tests/webapp/README.md с краткими инструкция
ми и целями тестов.
  - requirements: добавлен httpx для ASGI‑тестирования.
- Зачем: подтверждаем, что webapp корректно реализует OAuth‑флоу, персистентност
ь токенов и устойчив к гонкам при обновлении.
- Как проверить:
  - Установить зависимости: `pip install -r requirements.txt`
  - Запустить: `pytest -q tests/webapp`
  - Ожидаемо: все тесты зелёные; в конкурентном тесте refresh вызывается ровно о
дин раз.
- Обратная совместимость: да, без ломаний API; изменения локальны модулю webapp 
и тестам.
- Риски: низкие; сеть не используется (всё замокано), БД — временная.